### PR TITLE
Bump `balanced-match`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "index.js"
   ],
   "dependencies": {
-    "balanced-match": "^0.2.0"
+    "balanced-match": "^0.4.2"
   },
   "devDependencies": {
     "jscs": "^2.0.0",


### PR DESCRIPTION
Bumps `balanced-match` to the version used by `reduce-css-calc`.